### PR TITLE
Downgrade to PyQt4 to get the build working again

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -11,6 +11,7 @@ pyinstaller ^
     --exclude-module arcpy ^
     --exclude-module numpy ^
     --runtime-hook %~dp0hooks\rthooks\pyi_rth_arcpy.py ^
+    --runtime-hook %~dp0hooks\rthooks\pyi_rth_pyqt4.py ^
     --clean ^
     --noconsole ^
     --distpath %~dp0dist ^

--- a/buildtemplates.bat
+++ b/buildtemplates.bat
@@ -1,11 +1,13 @@
 @echo off
 
 setlocal EnableDelayedExpansion
-
 echo Converting UIC files in %~dp0src to Python modules...
 for /R %~dp0src %%F IN (*.ui) do (
     set "output=%%~dpnF"
     set "output=!output!_ui.py"
     echo Converting %%F to !output!
-    pyside2-uic.exe %%F -o !output!
+    call pyuic4.bat %%F -o !output!
+    if !errorlevel! neq 0 (
+        exit /b 1
+    )
 )

--- a/hooks/rthooks/pyi_rth_pyqt4.py
+++ b/hooks/rthooks/pyi_rth_pyqt4.py
@@ -1,0 +1,6 @@
+import sip
+
+API_NAMES = ['QDate', 'QDateTime', 'QString', 'QTextStream', 'QTime', 'QUrl', 'QVariant']
+API_VERSION = 2
+for name in API_NAMES:
+    sip.setapi(name, API_VERSION)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 archook
 logutils
+Qt.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 archook
 logutils
-Qt.py

--- a/src/aboutdialog/__init__.py
+++ b/src/aboutdialog/__init__.py
@@ -1,9 +1,9 @@
-from Qt import QtWidgets
+from PyQt4 import QtGui
 
 from aboutdialog_ui import Ui_AboutDialog
 
 
-class AboutDialog(QtWidgets.QDialog, Ui_AboutDialog):
+class AboutDialog(QtGui.QDialog, Ui_AboutDialog):
     def __init__(self, parent=None):
-        QtWidgets.QDialog.__init__(self, parent)
+        QtGui.QDialog.__init__(self, parent)
         self.setupUi(self)

--- a/src/aboutdialog/__init__.py
+++ b/src/aboutdialog/__init__.py
@@ -1,4 +1,4 @@
-from PySide2 import QtWidgets
+from Qt import QtWidgets
 
 from aboutdialog_ui import Ui_AboutDialog
 

--- a/src/datasetusagesreportdialog/__init__.py
+++ b/src/datasetusagesreportdialog/__init__.py
@@ -1,5 +1,5 @@
-from PySide2 import QtWidgets, QtCore
-from PySide2.QtCore import Qt
+from Qt import QtWidgets, QtCore, QtCompat
+from Qt.QtCore import Qt
 
 from ags_service_publisher.logging_io import setup_logger
 from ags_service_publisher.config_io import get_config
@@ -24,7 +24,7 @@ class DatasetUsagesReportDialog(QtWidgets.QDialog, Ui_DatasetUsagesReportDialog)
         self._acceptButton = self.buttonBox.button(QtWidgets.QDialogButtonBox.Ok)
         self._acceptButton.setText('Run report')
 
-        self.instancesTree.header().setSectionResizeMode(0, QtWidgets.QHeaderView.Stretch)
+        QtCompat.QHeaderView.setSectionResizeMode(self.instancesTree.header(), 0, QtWidgets.QHeaderView.Stretch)
 
         user_config = get_config('userconfig', config_dir=get_config_dir())
         for env_name, env in user_config['environments'].iteritems():
@@ -74,11 +74,11 @@ class DatasetUsagesReportDialog(QtWidgets.QDialog, Ui_DatasetUsagesReportDialog)
         return included_datasets, included_envs, included_instances
 
     def run_report_on_selected_items(self):
-        included_datasets, included_envs, included_instances = self.get_selected_items()
+        included_datasets, included_envs, included_instances = map(tuple, self.get_selected_items())
         self.runReport.emit(included_datasets, included_envs, included_instances, self.outputfileLineEdit.text() or None)
 
     def select_output_filename(self):
-        filename, _filter = QtWidgets.QFileDialog.getSaveFileName(
+        filename, _filter = QtCompat.QFileDialog.getSaveFileName(
             self,
             'Output filename',
             self.outputfileLineEdit.text(),

--- a/src/datasetusagesreportdialog/__init__.py
+++ b/src/datasetusagesreportdialog/__init__.py
@@ -1,5 +1,5 @@
-from Qt import QtWidgets, QtCore, QtCompat
-from Qt.QtCore import Qt
+from PyQt4 import QtGui, QtCore
+from PyQt4.QtCore import Qt
 
 from ags_service_publisher.logging_io import setup_logger
 from ags_service_publisher.config_io import get_config
@@ -12,28 +12,28 @@ from helpers.pathhelpers import get_config_dir
 log = setup_logger(__name__)
 
 
-class DatasetUsagesReportDialog(QtWidgets.QDialog, Ui_DatasetUsagesReportDialog):
+class DatasetUsagesReportDialog(QtGui.QDialog, Ui_DatasetUsagesReportDialog):
 
-    runReport = QtCore.Signal(tuple, tuple, tuple, str)
+    runReport = QtCore.pyqtSignal(tuple, tuple, tuple, str)
 
     def __init__(self, parent=None):
-        QtWidgets.QDialog.__init__(self, parent)
+        QtGui.QDialog.__init__(self, parent)
         self.setupUi(self)
 
         self.setWindowFlags(self.windowFlags() | Qt.WindowMaximizeButtonHint | Qt.WindowMinimizeButtonHint)
-        self._acceptButton = self.buttonBox.button(QtWidgets.QDialogButtonBox.Ok)
+        self._acceptButton = self.buttonBox.button(QtGui.QDialogButtonBox.Ok)
         self._acceptButton.setText('Run report')
 
-        QtCompat.QHeaderView.setSectionResizeMode(self.instancesTree.header(), 0, QtWidgets.QHeaderView.Stretch)
+        self.instancesTree.header().setResizeMode(0, QtGui.QHeaderView.Stretch)
 
         user_config = get_config('userconfig', config_dir=get_config_dir())
         for env_name, env in user_config['environments'].iteritems():
-            env_item = QtWidgets.QTreeWidgetItem(self.instancesTree)
+            env_item = QtGui.QTreeWidgetItem(self.instancesTree)
             env_item.setText(0, env_name)
             env_item.setText(1, 'Environment')
             env_item.setFlags(env_item.flags() | Qt.ItemIsTristate)
             for instance_name in env.get('ags_instances'):
-                instance_item = QtWidgets.QTreeWidgetItem(env_item)
+                instance_item = QtGui.QTreeWidgetItem(env_item)
                 instance_item.setText(0, instance_name)
                 instance_item.setText(1, 'AGS Instance')
                 instance_item.setCheckState(0, Qt.Unchecked)
@@ -75,10 +75,10 @@ class DatasetUsagesReportDialog(QtWidgets.QDialog, Ui_DatasetUsagesReportDialog)
 
     def run_report_on_selected_items(self):
         included_datasets, included_envs, included_instances = map(tuple, self.get_selected_items())
-        self.runReport.emit(included_datasets, included_envs, included_instances, self.outputfileLineEdit.text() or None)
+        self.runReport.emit(included_datasets, included_envs, included_instances, self.outputfileLineEdit.text() or '')
 
     def select_output_filename(self):
-        filename, _filter = QtCompat.QFileDialog.getSaveFileName(
+        filename = QtGui.QFileDialog.getSaveFileName(
             self,
             'Output filename',
             self.outputfileLineEdit.text(),

--- a/src/datasetusagesreportdialog/__init__.py
+++ b/src/datasetusagesreportdialog/__init__.py
@@ -75,7 +75,7 @@ class DatasetUsagesReportDialog(QtGui.QDialog, Ui_DatasetUsagesReportDialog):
 
     def run_report_on_selected_items(self):
         included_datasets, included_envs, included_instances = map(tuple, self.get_selected_items())
-        self.runReport.emit(included_datasets, included_envs, included_instances, self.outputfileLineEdit.text() or '')
+        self.runReport.emit(included_datasets, included_envs, included_instances, self.outputfileLineEdit.text() or None)
 
     def select_output_filename(self):
         filename = QtGui.QFileDialog.getSaveFileName(

--- a/src/datasetusagesreportdialog/datasetusagesreportdialog.ui
+++ b/src/datasetusagesreportdialog/datasetusagesreportdialog.ui
@@ -37,16 +37,16 @@
           </widget>
          </item>
          <item>
-          <widget class="QPlainTextEdit" name="includedDatasetsTextEdit">
+          <widget class="PlainTextEditWithPlaceholderText" name="includedDatasetsTextEdit">
            <property name="tabChangesFocus">
             <bool>true</bool>
            </property>
            <property name="lineWrapMode">
             <enum>QPlainTextEdit::NoWrap</enum>
            </property>
-           <!-- <property name="placeholderText">
+           <property name="placeholderText">
             <string>(Optional) Enter one or more dataset names or fnmatch-style filters, each on its own line.</string>
-           </property> -->
+           </property>
           </widget>
          </item>
         </layout>
@@ -152,6 +152,14 @@
    </item>
   </layout>
  </widget>
+<customwidgets>
+  <customwidget>
+   <class>PlainTextEditWithPlaceholderText</class>
+   <extends>QPlainTextEdit</extends>
+   <header>widgets/plaintexteditwithplaceholdertext.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections>
   <connection>

--- a/src/datasetusagesreportdialog/datasetusagesreportdialog.ui
+++ b/src/datasetusagesreportdialog/datasetusagesreportdialog.ui
@@ -44,9 +44,9 @@
            <property name="lineWrapMode">
             <enum>QPlainTextEdit::NoWrap</enum>
            </property>
-           <property name="placeholderText">
+           <!-- <property name="placeholderText">
             <string>(Optional) Enter one or more dataset names or fnmatch-style filters, each on its own line.</string>
-           </property>
+           </property> -->
           </widget>
          </item>
         </layout>

--- a/src/loghandlers/qtloghandler.py
+++ b/src/loghandlers/qtloghandler.py
@@ -1,5 +1,5 @@
 import logging
-from Qt import QtCore
+from PyQt4 import QtCore
 
 
 class QtLogHandler(logging.Handler):
@@ -23,7 +23,7 @@ class QtLogMessageEmitter(QtCore.QObject):
     QObject that emits a Qt signal with the log level and log message for each handled log record.
     """
 
-    messageEmitted = QtCore.Signal(str, str)
+    messageEmitted = QtCore.pyqtSignal(str, str)
 
     def __init__(self):
         super(QtLogMessageEmitter, self).__init__()

--- a/src/loghandlers/qtloghandler.py
+++ b/src/loghandlers/qtloghandler.py
@@ -1,5 +1,5 @@
 import logging
-from PySide2 import QtCore
+from Qt import QtCore
 
 
 class QtLogHandler(logging.Handler):

--- a/src/main.pyw
+++ b/src/main.pyw
@@ -1,7 +1,7 @@
 import multiprocessing
 import sys
 
-from PySide2 import QtWidgets
+from Qt import QtWidgets
 from ags_service_publisher.logging_io import setup_logger, setup_console_log_handler
 from ags_service_publisher.runner import root_logger
 

--- a/src/main.pyw
+++ b/src/main.pyw
@@ -1,7 +1,7 @@
 import multiprocessing
 import sys
 
-from Qt import QtWidgets
+from PyQt4 import QtGui
 from ags_service_publisher.logging_io import setup_logger, setup_console_log_handler
 from ags_service_publisher.runner import root_logger
 
@@ -15,7 +15,7 @@ def main():
     multiprocessing.freeze_support()
     setup_console_log_handler(root_logger, verbose=True)
     log.debug('Application started: {}'.format(get_app_path()))
-    app = QtWidgets.QApplication(sys.argv)
+    app = QtGui.QApplication(sys.argv)
     main_window = MainWindow()
     main_window.show()
     sys.exit(app.exec_())

--- a/src/main.pyw
+++ b/src/main.pyw
@@ -1,6 +1,14 @@
 import multiprocessing
 import sys
 
+if not hasattr(sys, 'frozen'):
+    import sip
+
+    API_NAMES = ['QDate', 'QDateTime', 'QString', 'QTextStream', 'QTime', 'QUrl', 'QVariant']
+    API_VERSION = 2
+    for name in API_NAMES:
+        sip.setapi(name, API_VERSION)
+
 from PyQt4 import QtGui
 from ags_service_publisher.logging_io import setup_logger, setup_console_log_handler
 from ags_service_publisher.runner import root_logger

--- a/src/mainwindow/__init__.py
+++ b/src/mainwindow/__init__.py
@@ -1,4 +1,4 @@
-from PySide2 import QtWidgets
+from Qt import QtWidgets
 from ags_service_publisher.runner import Runner, root_logger
 from ags_service_publisher.logging_io import setup_logger
 

--- a/src/mainwindow/__init__.py
+++ b/src/mainwindow/__init__.py
@@ -1,4 +1,4 @@
-from Qt import QtWidgets
+from PyQt4 import QtGui
 from ags_service_publisher.runner import Runner, root_logger
 from ags_service_publisher.logging_io import setup_logger
 
@@ -18,9 +18,9 @@ from workers.workerpool import WorkerPool
 log = setup_logger(__name__)
 
 
-class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
+class MainWindow(QtGui.QMainWindow, Ui_MainWindow):
     def __init__(self, parent=None):
-        QtWidgets.QMainWindow.__init__(self, parent)
+        QtGui.QMainWindow.__init__(self, parent)
         self.setupUi(self)
         self.actionPublish_Services.triggered.connect(self.show_publish_dialog)
         self.actionMXD_Data_Sources_Report.triggered.connect(self.show_mxd_report_dialog)
@@ -43,15 +43,15 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
 
     def closeEvent(self, event):
         log.debug('closeEvent triggered')
-        result = QtWidgets.QMessageBox.question(
+        result = QtGui.QMessageBox.question(
             self,
             'Exit - AGS Service Publisher',
             'Are you sure you want to exit?',
-            QtWidgets.QMessageBox.Yes,
-            QtWidgets.QMessageBox.No
+            QtGui.QMessageBox.Yes,
+            QtGui.QMessageBox.No
         )
 
-        if result == QtWidgets.QMessageBox.Yes:
+        if result == QtGui.QMessageBox.Yes:
             self.worker_pool.stop_all_workers()
             log.debug('Exiting application!')
             event.accept()
@@ -116,11 +116,11 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
 
         try:
             result_dialog.setWindowTitle('ArcGIS Install Info - AGS Service Publisher')
-            result_dialog.setIcon(QtWidgets.QMessageBox.Information)
+            result_dialog.setIcon(QtGui.QMessageBox.Information)
             result_dialog.setText(str(get_install_info()))
         except StandardError as e:
             result_dialog.setWindowTitle('Error - AGS Service Publisher')
-            result_dialog.setIcon(QtWidgets.QMessageBox.Critical)
+            result_dialog.setIcon(QtGui.QMessageBox.Critical)
             result_dialog.setText(str(e))
         finally:
             result_dialog.exec_()
@@ -130,11 +130,11 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
 
         try:
             result_dialog.setWindowTitle('Executable Path - AGS Service Publisher')
-            result_dialog.setIcon(QtWidgets.QMessageBox.Information)
+            result_dialog.setIcon(QtGui.QMessageBox.Information)
             result_dialog.setText(get_app_path())
         except StandardError as e:
             result_dialog.setWindowTitle('Error - AGS Service Publisher')
-            result_dialog.setIcon(QtWidgets.QMessageBox.Critical)
+            result_dialog.setIcon(QtGui.QMessageBox.Critical)
             result_dialog.setText(str(e))
         finally:
             result_dialog.exec_()

--- a/src/mxdreportdialog/__init__.py
+++ b/src/mxdreportdialog/__init__.py
@@ -68,7 +68,7 @@ class MXDReportDialog(QtGui.QDialog, Ui_MXDReportDialog):
 
     def run_report_on_selected_items(self):
         included_configs, included_services, included_envs = map(tuple, self.get_selected_items())
-        self.runReport.emit(included_configs, included_services, included_envs, self.outputfileLineEdit.text() or '')
+        self.runReport.emit(included_configs, included_services, included_envs, self.outputfileLineEdit.text() or None)
 
     def select_output_filename(self):
         filename = QtGui.QFileDialog.getSaveFileName(

--- a/src/mxdreportdialog/__init__.py
+++ b/src/mxdreportdialog/__init__.py
@@ -1,5 +1,5 @@
-from Qt import QtWidgets, QtCore, QtCompat
-from Qt.QtCore import Qt
+from PyQt4 import QtGui, QtCore
+from PyQt4.QtCore import Qt
 
 from ags_service_publisher.logging_io import setup_logger
 from ags_service_publisher.config_io import get_config
@@ -11,26 +11,26 @@ from helpers.pathhelpers import get_config_dir
 log = setup_logger(__name__)
 
 
-class MXDReportDialog(QtWidgets.QDialog, Ui_MXDReportDialog):
+class MXDReportDialog(QtGui.QDialog, Ui_MXDReportDialog):
 
-    runReport = QtCore.Signal(tuple, tuple, tuple, str)
+    runReport = QtCore.pyqtSignal(tuple, tuple, tuple, str)
 
     def __init__(self, parent=None):
-        QtWidgets.QDialog.__init__(self, parent)
+        QtGui.QDialog.__init__(self, parent)
         self.setupUi(self)
 
         self.setWindowFlags(self.windowFlags() | Qt.WindowMaximizeButtonHint | Qt.WindowMinimizeButtonHint)
-        self._acceptButton = self.buttonBox.button(QtWidgets.QDialogButtonBox.Ok)
+        self._acceptButton = self.buttonBox.button(QtGui.QDialogButtonBox.Ok)
         self._acceptButton.setText('Run report')
 
-        QtCompat.QHeaderView.setSectionResizeMode(self.envsTree.header(), 0, QtWidgets.QHeaderView.Stretch)
+        self.envsTree.header().setResizeMode(0, QtGui.QHeaderView.Stretch)
 
         self.selected_configs = ()
         self.selected_services = ()
 
         user_config = get_config('userconfig', config_dir=get_config_dir())
         for env_name, env in user_config['environments'].iteritems():
-            env_item = QtWidgets.QTreeWidgetItem(self.envsTree)
+            env_item = QtGui.QTreeWidgetItem(self.envsTree)
             env_item.setText(0, env_name)
             env_item.setText(1, 'Environment')
             env_item.setCheckState(0, Qt.Unchecked)
@@ -68,10 +68,10 @@ class MXDReportDialog(QtWidgets.QDialog, Ui_MXDReportDialog):
 
     def run_report_on_selected_items(self):
         included_configs, included_services, included_envs = map(tuple, self.get_selected_items())
-        self.runReport.emit(included_configs, included_services, included_envs, self.outputfileLineEdit.text() or None)
+        self.runReport.emit(included_configs, included_services, included_envs, self.outputfileLineEdit.text() or '')
 
     def select_output_filename(self):
-        filename, _filter = QtCompat.QFileDialog.getSaveFileName(
+        filename = QtGui.QFileDialog.getSaveFileName(
             self,
             'Output filename',
             self.outputfileLineEdit.text(),

--- a/src/mxdreportdialog/__init__.py
+++ b/src/mxdreportdialog/__init__.py
@@ -1,5 +1,5 @@
-from PySide2 import QtWidgets, QtCore
-from PySide2.QtCore import Qt
+from Qt import QtWidgets, QtCore, QtCompat
+from Qt.QtCore import Qt
 
 from ags_service_publisher.logging_io import setup_logger
 from ags_service_publisher.config_io import get_config
@@ -23,7 +23,7 @@ class MXDReportDialog(QtWidgets.QDialog, Ui_MXDReportDialog):
         self._acceptButton = self.buttonBox.button(QtWidgets.QDialogButtonBox.Ok)
         self._acceptButton.setText('Run report')
 
-        self.envsTree.header().setSectionResizeMode(0, QtWidgets.QHeaderView.Stretch)
+        QtCompat.QHeaderView.setSectionResizeMode(self.envsTree.header(), 0, QtWidgets.QHeaderView.Stretch)
 
         self.selected_configs = ()
         self.selected_services = ()
@@ -67,11 +67,11 @@ class MXDReportDialog(QtWidgets.QDialog, Ui_MXDReportDialog):
         return self.selected_configs, self.selected_services, included_envs
 
     def run_report_on_selected_items(self):
-        included_configs, included_services, included_envs = self.get_selected_items()
+        included_configs, included_services, included_envs = map(tuple, self.get_selected_items())
         self.runReport.emit(included_configs, included_services, included_envs, self.outputfileLineEdit.text() or None)
 
     def select_output_filename(self):
-        filename, _filter = QtWidgets.QFileDialog.getSaveFileName(
+        filename, _filter = QtCompat.QFileDialog.getSaveFileName(
             self,
             'Output filename',
             self.outputfileLineEdit.text(),

--- a/src/mxdreportdialog/mxdreportdialog.ui
+++ b/src/mxdreportdialog/mxdreportdialog.ui
@@ -131,9 +131,9 @@
       </item>
       <item>
        <widget class="QLineEdit" name="outputfileLineEdit">
-        <property name="placeholderText">
+        <!-- <property name="placeholderText">
          <string>(Optional) Output filename will be generated automatically if not specified.</string>
-        </property>
+        </property> -->
        </widget>
       </item>
       <item>

--- a/src/mxdreportdialog/mxdreportdialog.ui
+++ b/src/mxdreportdialog/mxdreportdialog.ui
@@ -131,9 +131,9 @@
       </item>
       <item>
        <widget class="QLineEdit" name="outputfileLineEdit">
-        <!-- <property name="placeholderText">
+        <property name="placeholderText">
          <string>(Optional) Output filename will be generated automatically if not specified.</string>
-        </property> -->
+        </property>
        </widget>
       </item>
       <item>

--- a/src/publishdialog/__init__.py
+++ b/src/publishdialog/__init__.py
@@ -1,5 +1,5 @@
-from PySide2 import QtWidgets, QtCore
-from PySide2.QtCore import Qt
+from Qt import QtWidgets, QtCore, QtCompat
+from Qt.QtCore import Qt
 
 from ags_service_publisher.logging_io import setup_logger
 from ags_service_publisher.config_io import get_config
@@ -23,7 +23,7 @@ class PublishDialog(QtWidgets.QDialog, Ui_PublishDialog):
         self._acceptButton = self.buttonBox.button(QtWidgets.QDialogButtonBox.Ok)
         self._acceptButton.setText('Publish selected services')
 
-        self.instancesTree.header().setSectionResizeMode(0, QtWidgets.QHeaderView.Stretch)
+        QtCompat.QHeaderView.setSectionResizeMode(self.instancesTree.header(), 0, QtWidgets.QHeaderView.Stretch)
 
         self.selected_configs = ()
         self.selected_services = ()
@@ -77,4 +77,4 @@ class PublishDialog(QtWidgets.QDialog, Ui_PublishDialog):
         return self.selected_configs, self.selected_services, included_envs, included_instances
 
     def publish_selected_items(self):
-        self.publishSelected.emit(*self.get_selected_items())
+        self.publishSelected.emit(*map(tuple, self.get_selected_items()))

--- a/src/publishdialog/__init__.py
+++ b/src/publishdialog/__init__.py
@@ -1,5 +1,5 @@
-from Qt import QtWidgets, QtCore, QtCompat
-from Qt.QtCore import Qt
+from PyQt4 import QtGui, QtCore
+from PyQt4.QtCore import Qt
 
 from ags_service_publisher.logging_io import setup_logger
 from ags_service_publisher.config_io import get_config
@@ -11,31 +11,31 @@ from helpers.pathhelpers import get_config_dir
 log = setup_logger(__name__)
 
 
-class PublishDialog(QtWidgets.QDialog, Ui_PublishDialog):
+class PublishDialog(QtGui.QDialog, Ui_PublishDialog):
 
-    publishSelected = QtCore.Signal(tuple, tuple, tuple, tuple)
+    publishSelected = QtCore.pyqtSignal(tuple, tuple, tuple, tuple)
 
     def __init__(self, parent=None):
-        QtWidgets.QDialog.__init__(self, parent)
+        QtGui.QDialog.__init__(self, parent)
         self.setupUi(self)
 
         self.setWindowFlags(self.windowFlags() | Qt.WindowMaximizeButtonHint | Qt.WindowMinimizeButtonHint)
-        self._acceptButton = self.buttonBox.button(QtWidgets.QDialogButtonBox.Ok)
+        self._acceptButton = self.buttonBox.button(QtGui.QDialogButtonBox.Ok)
         self._acceptButton.setText('Publish selected services')
 
-        QtCompat.QHeaderView.setSectionResizeMode(self.instancesTree.header(), 0, QtWidgets.QHeaderView.Stretch)
+        self.instancesTree.header().setResizeMode(0, QtGui.QHeaderView.Stretch)
 
         self.selected_configs = ()
         self.selected_services = ()
 
         user_config = get_config('userconfig', config_dir=get_config_dir())
         for env_name, env in user_config['environments'].iteritems():
-            env_item = QtWidgets.QTreeWidgetItem(self.instancesTree)
+            env_item = QtGui.QTreeWidgetItem(self.instancesTree)
             env_item.setText(0, env_name)
             env_item.setText(1, 'Environment')
             env_item.setFlags(env_item.flags() | Qt.ItemIsTristate)
             for instance_name in env.get('ags_instances'):
-                instance_item = QtWidgets.QTreeWidgetItem(env_item)
+                instance_item = QtGui.QTreeWidgetItem(env_item)
                 instance_item.setText(0, instance_name)
                 instance_item.setText(1, 'AGS Instance')
                 instance_item.setCheckState(0, Qt.Unchecked)

--- a/src/resultdialog/__init__.py
+++ b/src/resultdialog/__init__.py
@@ -1,4 +1,4 @@
-from PySide2 import QtWidgets
+from Qt import QtWidgets
 
 
 class ResultDialog(QtWidgets.QMessageBox):

--- a/src/resultdialog/__init__.py
+++ b/src/resultdialog/__init__.py
@@ -1,6 +1,6 @@
-from Qt import QtWidgets
+from PyQt4 import QtGui
 
 
-class ResultDialog(QtWidgets.QMessageBox):
+class ResultDialog(QtGui.QMessageBox):
     def __init__(self, parent=None):
-        QtWidgets.QMessageBox.__init__(self, parent)
+        QtGui.QMessageBox.__init__(self, parent)

--- a/src/serviceselector/__init__.py
+++ b/src/serviceselector/__init__.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
+from pkg_resources import parse_version
 
-from PySide2 import QtWidgets, QtCore, QtGui
+from Qt import QtWidgets, QtCore, QtGui, QtCompat, __qt_version__
 
 from ags_service_publisher.logging_io import setup_logger
 from ags_service_publisher.config_io import get_configs
@@ -29,7 +30,8 @@ class ServiceSelector(QtWidgets.QWidget):
         self.setLayout(self.layout)
 
         self.tab_widget = QtWidgets.QTabWidget(self)
-        self.tab_widget.setTabBarAutoHide(True)
+        if parse_version(__qt_version__) >= parse_version('5.4'):
+            self.tab_widget.setTabBarAutoHide(True)
         self.layout.addWidget(self.tab_widget)
 
         self.model = ServiceModel(0, 3, self)
@@ -85,11 +87,11 @@ class ServiceSelector(QtWidgets.QWidget):
         tree_view.setFrameShape(QtWidgets.QFrame.NoFrame)
         tree_view.header().setMinimumSectionSize(100)
         tree_view.header().setStretchLastSection(False)
-        tree_view.header().setSectionResizeMode(0, QtWidgets.QHeaderView.Stretch)
+        QtCompat.QHeaderView.setSectionResizeMode(tree_view.header(), 0, QtWidgets.QHeaderView.Stretch)
         self.tab_widget.addTab(tree_view, heading)
 
     def selected_items_changed(self):
-        self.selectionChanged.emit(*self.get_selected_items())
+        self.selectionChanged.emit(*map(tuple, self.get_selected_items()))
 
     def get_selected_items(self):
         log.debug('Getting selected items')

--- a/src/serviceselector/__init__.py
+++ b/src/serviceselector/__init__.py
@@ -55,8 +55,8 @@ class ServiceSelector(QtGui.QWidget):
             default_service_properties = config.get('default_service_properties')
             for service_name, service_type, _ in normalize_services(services, default_service_properties):
                 service_item = CheckableItem(service_name)
-                config_item.appendRow((service_item, QtGui.QStandardItem('{} Service'.format(service_type)), QtGui.QStandardItem(category) if category else QtGui.QStandardItem()))
-            self.model.appendRow((config_item, QtGui.QStandardItem('Config Name'), QtGui.QStandardItem(category) if category else QtGui.QStandardItem()))
+                config_item.appendRow((service_item, QtGui.QStandardItem('{} Service'.format(service_type)), QtGui.QStandardItem(category)))
+            self.model.appendRow((config_item, QtGui.QStandardItem('Config Name'), QtGui.QStandardItem(category)))
 
         self.add_tab(self.model, 'All')
 
@@ -171,5 +171,5 @@ class NoCategoryFilterProxyModel(QtGui.QSortFilterProxyModel):
             model = self.sourceModel()
             category_index = model.index(source_row, self.category_column, source_parent)
             category = model.data(category_index)
-            return category.toString() == ''
+            return not category
         return True

--- a/src/widgets/plaintexteditwithplaceholdertext.py
+++ b/src/widgets/plaintexteditwithplaceholdertext.py
@@ -1,0 +1,51 @@
+from PyQt4 import QtGui
+from PyQt4.QtCore import Qt
+
+# Adapted from https://stackoverflow.com/a/43882058
+class PlainTextEditWithPlaceholderText(QtGui.QPlainTextEdit):
+    def __init__(self, parent=None):
+        super(PlainTextEditWithPlaceholderText, self).__init__(parent)
+        self.placeholderText = ''
+
+    def setPlaceholderText(self, text):
+        self.placeholderText = text
+
+    def paintEvent(self, event):
+        """
+        Implements the same behavior as QLineEdit's setPlaceholderText()
+        Draw the placeholder text when there is no text entered.
+        """
+        document = self.document()
+        if self.placeholderText and document.isEmpty():
+            offset = self.contentOffset()
+            viewport = self.viewport()
+            painter = QtGui.QPainter(viewport)
+            painter.setBrushOrigin(offset)
+
+            color = self.palette().text().color()
+            color.setAlpha(128)
+            painter.setPen(color)
+
+            margin = int(document.documentMargin())
+            text_rect = viewport.rect().adjusted(margin, margin, 0, 0)
+            painter.drawText(text_rect, Qt.AlignTop | Qt.TextWordWrap, self.placeholderText)
+
+            if (self.hasFocus()):
+                context = self.getPaintContext()
+                cursor_position = context.cursorPosition
+                if cursor_position == -1:
+                    # Cursor blinking means we don't need to draw it on this event
+                    pass
+                else:
+                    block = self.firstVisibleBlock()
+                    block_position = block.position()
+                    layout = block.layout()
+                    if cursor_position < -1:
+                        cursor_position = layout.preeditAreaPosition() - (cursor_position + 2)
+                    else:
+                        cursor_position -= block_position
+                    layout.drawCursor(painter, offset, cursor_position, self.cursorWidth())
+
+            viewport.update()
+        else:
+            super(PlainTextEditWithPlaceholderText, self).paintEvent(event)

--- a/src/workers/subprocessworker.py
+++ b/src/workers/subprocessworker.py
@@ -3,7 +3,7 @@ import multiprocessing
 import sys
 import traceback
 
-from Qt import QtCore
+from PyQt4 import QtCore
 from ags_service_publisher.logging_io import setup_logger
 from logutils.queue import QueueHandler, QueueListener
 
@@ -28,8 +28,8 @@ class SubprocessWorker(QtCore.QObject):
             - Return value or exception instance (object)
     """
 
-    messageEmitted = QtCore.Signal(int, str, str)
-    resultEmitted = QtCore.Signal(int, int, object)
+    messageEmitted = QtCore.pyqtSignal(int, str, str)
+    resultEmitted = QtCore.pyqtSignal(int, int, object)
 
     get_next_worker_id = itertools.count().next
 
@@ -73,7 +73,7 @@ class SubprocessWorker(QtCore.QObject):
             message = 'Subprocess {} (pid {}) is still active'.format(self.process.name, self.process.pid)
             log.debug(message)
 
-    @QtCore.Slot()
+    @QtCore.pyqtSlot()
     def start(self):
         if self.running:
             log.warn('Worker {} already started on thread {}'.format(self.id, str(self.thread)))
@@ -96,7 +96,7 @@ class SubprocessWorker(QtCore.QObject):
         self.timer.start(self.timer_check_interval)
         log.debug('Subprocess {} (pid {}) started'.format(self.process.name, self.process.pid))
 
-    @QtCore.Slot()
+    @QtCore.pyqtSlot()
     def stop(self):
         if not self.running:
             log.warn('Worker {} already stopped on thread {}'.format(self.id, str(self.thread)))
@@ -112,7 +112,7 @@ class SubprocessWorker(QtCore.QObject):
 
         self.log_queue_listener.stop()
 
-    @QtCore.Slot(str, str)
+    @QtCore.pyqtSlot(str, str)
     def handle_message(self, level, message):
         self.messageEmitted.emit(self.id, level, message)
 

--- a/src/workers/subprocessworker.py
+++ b/src/workers/subprocessworker.py
@@ -3,7 +3,7 @@ import multiprocessing
 import sys
 import traceback
 
-from PySide2 import QtCore
+from Qt import QtCore
 from ags_service_publisher.logging_io import setup_logger
 from logutils.queue import QueueHandler, QueueListener
 


### PR DESCRIPTION
Due to [MSVC incompatibilities between Qt5 and Python 2.7 on Windows](https://wiki.qt.io/Qt_for_Python/Considerations#Missing_Windows_.2F_Python_2.7_release), we had to revert back to PyQt4 for our Qt dependency. Previously we were using an alpha version of Qt for Python 5.11 that is no longer available, and they no longer offer wheels for Python 2.7 on Windows.